### PR TITLE
feat(#15): Due notifications window on startup

### DIFF
--- a/internal/model/todo.go
+++ b/internal/model/todo.go
@@ -97,6 +97,16 @@ func (t *Todo) IsOverdue() bool {
 	return *t.DueAt < startOfToday()
 }
 
+// IsDueToday returns true if the todo is due today (not overdue, not done).
+func (t *Todo) IsDueToday() bool {
+	if t.Done || t.DueAt == nil {
+		return false
+	}
+	today := startOfToday()
+	tomorrow := today + 86400
+	return *t.DueAt >= today && *t.DueAt < tomorrow
+}
+
 func startOfToday() int64 {
 	now := time.Now()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Unix()

--- a/internal/model/todo_test.go
+++ b/internal/model/todo_test.go
@@ -113,6 +113,38 @@ func TestIsOverdue(t *testing.T) {
 	}
 }
 
+func TestIsDueToday(t *testing.T) {
+	now := time.Now()
+	todayNoon := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location()).Unix()
+	yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 12, 0, 0, 0, now.Location()).Unix()
+	tomorrow := time.Date(now.Year(), now.Month(), now.Day()+1, 12, 0, 0, 0, now.Location()).Unix()
+
+	dueToday := &Todo{DueAt: &todayNoon}
+	if !dueToday.IsDueToday() {
+		t.Error("expected IsDueToday=true for today's noon timestamp")
+	}
+
+	notYet := &Todo{DueAt: &tomorrow}
+	if notYet.IsDueToday() {
+		t.Error("expected IsDueToday=false for tomorrow")
+	}
+
+	overdue := &Todo{DueAt: &yesterday}
+	if overdue.IsDueToday() {
+		t.Error("expected IsDueToday=false for yesterday (overdue)")
+	}
+
+	done := &Todo{Done: true, DueAt: &todayNoon}
+	if done.IsDueToday() {
+		t.Error("done todos should not be due today")
+	}
+
+	noDate := &Todo{}
+	if noDate.IsDueToday() {
+		t.Error("todos without due date should not be due today")
+	}
+}
+
 func TestGetAllTags(t *testing.T) {
 	todos := []*Todo{
 		{Text: "task #alpha"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -163,6 +163,9 @@ type Model struct {
 	// Project mode state.
 	projectDirName string // basename of git root for title; empty = global
 	projectErr     string // set when project mode failed (not in git repo, etc.)
+
+	// Due notifications overlay.
+	notif notifState
 }
 
 // NewModel creates a new root model, loading todos from disk.
@@ -198,6 +201,12 @@ func NewModel(projectMode bool) Model {
 	ti.CharLimit = 500
 	ti.Width = 50
 
+	// Build notification state if enabled.
+	var notif notifState
+	if cfg.DueNotifications.Enabled && cfg.DueNotifications.OnStartup {
+		notif = newNotifState(todos)
+	}
+
 	return Model{
 		projectMode:    projectMode,
 		projectDirName: projectDirName,
@@ -209,6 +218,7 @@ func NewModel(projectMode bool) Model {
 		ti:             ti,
 		tagWin:         newTagWindowState(),
 		nested:         newNestedState(),
+		notif:          notif,
 	}
 }
 
@@ -224,6 +234,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = ws.Width
 		m.height = ws.Height
 		return m, nil
+	}
+
+	// Handle jump-to-todo message from notification overlay.
+	if jmp, ok := msg.(jumpToTodoMsg); ok {
+		visible := m.visibleTodos()
+		for i, t := range visible {
+			if t.ID == jmp.todoID {
+				m.cursor = i
+				break
+			}
+		}
+		return m, nil
+	}
+
+	// Notification overlay intercepts input when open.
+	if m.notif.open {
+		return m.updateNotifications(msg)
 	}
 
 	// Help window intercepts input when open.
@@ -782,6 +809,12 @@ func (m Model) View() string {
 	if m.scratchpad.open {
 		padView := m.renderScratchpad()
 		return lipgloss.JoinHorizontal(lipgloss.Top, padView, "  ", mainView)
+	}
+
+	// Due notifications overlay — rendered above main view (stacked).
+	if m.notif.open {
+		notifView := m.renderNotifications()
+		return lipgloss.JoinVertical(lipgloss.Left, notifView, "\n", mainView)
 	}
 
 	// Help window overlay — rendered side-by-side (right of main).

--- a/internal/ui/notifications.go
+++ b/internal/ui/notifications.go
@@ -1,0 +1,175 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/karimStekelenburg/dooing-tmux/internal/model"
+)
+
+var (
+	notifBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("214")).
+				Padding(0, 2).
+				Width(55)
+
+	notifTitleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("214"))
+
+	notifSectionStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("196"))
+
+	notifDueTodaySectionStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("214"))
+
+	notifCursorStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("212"))
+
+	notifFooterStyle = lipgloss.NewStyle().
+				Faint(true)
+)
+
+// notifItem wraps a todo with its category (overdue or due-today).
+type notifItem struct {
+	todo     *model.Todo
+	overdue  bool // false = due today
+}
+
+// notifState holds all state for the due notifications overlay.
+type notifState struct {
+	open   bool
+	items  []notifItem
+	cursor int
+}
+
+// newNotifState scans todos and returns a notifState (open only if there are items).
+func newNotifState(todos []*model.Todo) notifState {
+	var items []notifItem
+	for _, t := range todos {
+		if t.IsOverdue() {
+			items = append(items, notifItem{todo: t, overdue: true})
+		} else if t.IsDueToday() {
+			items = append(items, notifItem{todo: t, overdue: false})
+		}
+	}
+	return notifState{
+		open:  len(items) > 0,
+		items: items,
+	}
+}
+
+// jumpToTodoMsg is a tea.Msg that requests the main model to jump its cursor
+// to the todo with the given ID.
+type jumpToTodoMsg struct {
+	todoID string
+}
+
+// updateNotifications handles input when the notification overlay is open.
+func (m Model) updateNotifications(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch key.String() {
+	case "j", "down":
+		if m.notif.cursor < len(m.notif.items)-1 {
+			m.notif.cursor++
+		}
+	case "k", "up":
+		if m.notif.cursor > 0 {
+			m.notif.cursor--
+		}
+	case "enter":
+		if m.notif.cursor >= 0 && m.notif.cursor < len(m.notif.items) {
+			id := m.notif.items[m.notif.cursor].todo.ID
+			m.notif.open = false
+			// Jump cursor to the selected todo in the main list.
+			return m, func() tea.Msg { return jumpToTodoMsg{todoID: id} }
+		}
+	case "q", "esc":
+		m.notif.open = false
+	}
+	return m, nil
+}
+
+// renderNotifications returns the styled notification overlay string.
+func (m Model) renderNotifications() string {
+	// Build dynamic title.
+	var overdue, dueToday int
+	for _, item := range m.notif.items {
+		if item.overdue {
+			overdue++
+		} else {
+			dueToday++
+		}
+	}
+	parts := []string{}
+	if overdue > 0 {
+		parts = append(parts, fmt.Sprintf("%d overdue", overdue))
+	}
+	if dueToday > 0 {
+		parts = append(parts, fmt.Sprintf("%d due today", dueToday))
+	}
+	title := " " + strings.Join(parts, ", ") + " "
+
+	var sb strings.Builder
+	sb.WriteString(notifTitleStyle.Render(title))
+	sb.WriteString("\n\n")
+
+	// Render overdue section.
+	if overdue > 0 {
+		sb.WriteString(notifSectionStyle.Render("Overdue"))
+		sb.WriteString("\n")
+		idx := 0
+		for _, item := range m.notif.items {
+			if !item.overdue {
+				continue
+			}
+			line := renderTodo(item.todo, m.cfg.PriorityGroups)
+			if idx == m.notif.cursor {
+				sb.WriteString(notifCursorStyle.Render("> ") + line)
+			} else {
+				sb.WriteString("  " + line)
+			}
+			sb.WriteString("\n")
+			idx++
+		}
+	}
+
+	// Render due today section.
+	if dueToday > 0 {
+		if overdue > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(notifDueTodaySectionStyle.Render("Due Today"))
+		sb.WriteString("\n")
+		idx := overdue
+		for _, item := range m.notif.items {
+			if item.overdue {
+				continue
+			}
+			line := renderTodo(item.todo, m.cfg.PriorityGroups)
+			if idx == m.notif.cursor {
+				sb.WriteString(notifCursorStyle.Render("> ") + line)
+			} else {
+				sb.WriteString("  " + line)
+			}
+			sb.WriteString("\n")
+			idx++
+		}
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(notifFooterStyle.Render("[j/k] navigate  [Enter] jump to todo  [q/Esc] close"))
+
+	return notifBorderStyle.Render(sb.String())
+}

--- a/internal/ui/notifications_test.go
+++ b/internal/ui/notifications_test.go
@@ -1,0 +1,181 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/karimStekelenburg/dooing-tmux/internal/model"
+)
+
+func todoWithDue(text string, daysOffset int) *model.Todo {
+	t := model.NewTodo(text)
+	now := time.Now()
+	day := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, now.Location())
+	ts := day.AddDate(0, 0, daysOffset).Unix()
+	t.DueAt = &ts
+	return t
+}
+
+func TestNewNotifState_Empty(t *testing.T) {
+	ns := newNotifState([]*model.Todo{})
+	if ns.open {
+		t.Error("expected notif to be closed when no todos")
+	}
+	if len(ns.items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(ns.items))
+	}
+}
+
+func TestNewNotifState_Overdue(t *testing.T) {
+	todos := []*model.Todo{
+		todoWithDue("overdue task", -2),
+	}
+	ns := newNotifState(todos)
+	if !ns.open {
+		t.Error("expected notif to be open")
+	}
+	if len(ns.items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(ns.items))
+	}
+	if !ns.items[0].overdue {
+		t.Error("expected item to be overdue")
+	}
+}
+
+func TestNewNotifState_DueToday(t *testing.T) {
+	todos := []*model.Todo{
+		todoWithDue("due today task", 0),
+	}
+	ns := newNotifState(todos)
+	if !ns.open {
+		t.Error("expected notif to be open")
+	}
+	if len(ns.items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(ns.items))
+	}
+	if ns.items[0].overdue {
+		t.Error("expected item to be due today, not overdue")
+	}
+}
+
+func TestNewNotifState_SkipsDone(t *testing.T) {
+	overdue := todoWithDue("overdue but done", -2)
+	overdue.Done = true
+	dueToday := todoWithDue("due today but done", 0)
+	dueToday.Done = true
+	ns := newNotifState([]*model.Todo{overdue, dueToday})
+	if ns.open {
+		t.Error("expected notif to be closed for done todos")
+	}
+}
+
+func TestNewNotifState_SkipsFuture(t *testing.T) {
+	ns := newNotifState([]*model.Todo{
+		todoWithDue("future task", 5),
+	})
+	if ns.open {
+		t.Error("expected notif to be closed for future due dates")
+	}
+}
+
+func TestUpdateNotifications_Navigation(t *testing.T) {
+	m := Model{
+		notif: notifState{
+			open: true,
+			items: []notifItem{
+				{todo: model.NewTodo("a"), overdue: true},
+				{todo: model.NewTodo("b"), overdue: false},
+			},
+			cursor: 0,
+		},
+	}
+
+	// Move down.
+	newM, _ := m.updateNotifications(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m2 := newM.(Model)
+	if m2.notif.cursor != 1 {
+		t.Errorf("cursor after j: got %d, want 1", m2.notif.cursor)
+	}
+
+	// Move up.
+	newM2, _ := m2.updateNotifications(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m3 := newM2.(Model)
+	if m3.notif.cursor != 0 {
+		t.Errorf("cursor after k: got %d, want 0", m3.notif.cursor)
+	}
+}
+
+func TestUpdateNotifications_Close(t *testing.T) {
+	m := Model{
+		notif: notifState{
+			open:   true,
+			items:  []notifItem{{todo: model.NewTodo("x"), overdue: true}},
+			cursor: 0,
+		},
+	}
+
+	for _, key := range []string{"q", "esc"} {
+		var ktype tea.KeyType
+		if key == "esc" {
+			ktype = tea.KeyEsc
+		} else {
+			ktype = tea.KeyRunes
+		}
+		newM, _ := m.updateNotifications(tea.KeyMsg{Type: ktype, Runes: []rune(key)})
+		m2 := newM.(Model)
+		if m2.notif.open {
+			t.Errorf("expected notif to close on %q", key)
+		}
+	}
+}
+
+func TestUpdateNotifications_Enter(t *testing.T) {
+	todo := model.NewTodo("important task")
+	m := Model{
+		notif: notifState{
+			open:   true,
+			items:  []notifItem{{todo: todo, overdue: true}},
+			cursor: 0,
+		},
+	}
+
+	newM, cmd := m.updateNotifications(tea.KeyMsg{Type: tea.KeyEnter})
+	m2 := newM.(Model)
+
+	if m2.notif.open {
+		t.Error("expected notif to close after Enter")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd to be returned")
+	}
+
+	// Execute the cmd to get the message.
+	msg := cmd()
+	jmp, ok := msg.(jumpToTodoMsg)
+	if !ok {
+		t.Fatalf("expected jumpToTodoMsg, got %T", msg)
+	}
+	if jmp.todoID != todo.ID {
+		t.Errorf("jumpToTodoMsg.todoID = %q, want %q", jmp.todoID, todo.ID)
+	}
+}
+
+func TestModel_JumpToTodoMsg(t *testing.T) {
+	todos := []*model.Todo{
+		model.NewTodo("first"),
+		model.NewTodo("second"),
+		model.NewTodo("third"),
+	}
+	m := Model{
+		todos:  todos,
+		cursor: 0,
+	}
+
+	newM, _ := m.Update(jumpToTodoMsg{todoID: todos[1].ID})
+	m2 := newM.(Model)
+	if m2.cursor != 1 {
+		t.Errorf("cursor after jump: got %d, want 1", m2.cursor)
+	}
+}


### PR DESCRIPTION
## Summary

- On startup, scans all todos for overdue and due-today items and shows a centered notification overlay (skipped if nothing is due)
- Overlay has two labeled sections: **Overdue** (red header) and **Due Today** (amber header), with j/k navigation
- `Enter` closes the overlay and jumps the main cursor to the selected todo
- `q`/`Esc` closes the overlay without navigation
- Adds `IsDueToday()` method to `model.Todo` alongside the existing `IsOverdue()`
- Uses existing config keys `due_notifications.enabled` and `due_notifications.on_startup` (both default to `true`)

Closes #15

## Test plan

- [x] Overlay state: empty list → closed; overdue todo → open; due-today todo → open; done todos → skipped; future todos → skipped
- [x] j/k navigation updates cursor correctly with boundary clamping
- [x] q and Esc close the overlay
- [x] Enter closes overlay and emits jumpToTodoMsg with correct ID
- [x] Model.Update handles jumpToTodoMsg and moves cursor to correct visible index
- [x] IsDueToday: today noon → true; yesterday → false; tomorrow → false; done → false; no date → false
- [x] Full `go test ./...` passes