### PR TITLE
feat(#16): QR code LAN sharing via HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Thumbs.db
 
 # Go
 vendor/
+.claude/worktrees/

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	ProjectFile         string                    `toml:"project_file"`
 	AutoGitignore       string                    `toml:"auto_gitignore"` // "true", "false", "prompt"
 	OnMissingProject    string                    `toml:"on_missing_project"` // "prompt", "auto_create"
+	ServePort           int                       `toml:"serve_port"` // HTTP server port (default 7283)
 }
 
 // Defaults returns a Config with sensible defaults matching the original plugin.
@@ -99,6 +100,7 @@ func Defaults() Config {
 		ProjectFile:         "dooing.json",
 		AutoGitignore:       "prompt",
 		OnMissingProject:    "prompt",
+		ServePort:           7283,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,176 @@
+// Package server provides a read-only HTTP server for sharing todos over LAN
+// via a QR code.
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	qrcode "github.com/skip2/go-qrcode"
+
+	"github.com/karimStekelenburg/dooing-tmux/internal/model"
+)
+
+// Server exposes the current todo list over HTTP on a configurable port.
+type Server struct {
+	port   int
+	mu     sync.RWMutex
+	todos  []*model.Todo
+	httpSrv *http.Server
+	addr   string // resolved "host:port" after Start
+}
+
+// New creates a new Server that will listen on the given port.
+func New(port int) *Server {
+	s := &Server{port: port}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/todos", s.handleTodos)
+	mux.HandleFunc("/", s.handleRoot)
+	s.httpSrv = &http.Server{Handler: mux}
+	return s
+}
+
+// SetTodos atomically replaces the todo list served by the HTTP endpoints.
+func (s *Server) SetTodos(todos []*model.Todo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]*model.Todo, len(todos))
+	copy(cp, todos)
+	s.todos = cp
+}
+
+// Addr returns the resolved "host:port" string, available after Start.
+func (s *Server) Addr() string {
+	return s.addr
+}
+
+// Start begins listening in a background goroutine. The ctx is used for graceful
+// shutdown — when it is cancelled the server stops accepting new connections.
+// The returned error channel receives at most one value (nil on clean shutdown, non-nil otherwise).
+func (s *Server) Start(ctx context.Context) (<-chan error, error) {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	if err != nil {
+		return nil, fmt.Errorf("listen on port %d: %w", s.port, err)
+	}
+
+	lanIP := lanIP()
+	s.addr = fmt.Sprintf("%s:%d", lanIP, s.port)
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- s.httpSrv.Serve(ln)
+	}()
+
+	// Shutdown when ctx is cancelled.
+	go func() {
+		<-ctx.Done()
+		_ = s.httpSrv.Shutdown(context.Background())
+	}()
+
+	return errc, nil
+}
+
+func (s *Server) handleTodos(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	todos := s.todos
+	s.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if todos == nil {
+		todos = []*model.Todo{}
+	}
+	_ = enc.Encode(todos)
+}
+
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	todosURL := fmt.Sprintf("http://%s/todos", s.addr)
+
+	// Generate QR code as PNG, then embed as inline SVG-like data URI.
+	var qrPNG []byte
+	var qrErr string
+	pngBytes, err := qrcode.Encode(todosURL, qrcode.Medium, 256)
+	if err != nil {
+		qrErr = err.Error()
+	} else {
+		qrPNG = pngBytes
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	var buf bytes.Buffer
+	buf.WriteString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>dooing – share todos</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 480px; margin: 3rem auto; padding: 0 1rem; text-align: center; background: #0f0f0f; color: #e0e0e0; }
+  h1 { color: #9b8fef; margin-bottom: 0.25rem; }
+  p  { color: #999; margin-top: 0; }
+  .url { font-size: 1rem; background: #1e1e1e; border-radius: 6px; padding: 0.6rem 1rem; display: inline-block; word-break: break-all; color: #86e0b0; margin: 1rem 0; }
+  img { border: 4px solid #fff; border-radius: 8px; margin-top: 1rem; }
+  .err { color: #f87171; }
+</style>
+</head>
+<body>
+<h1>dooing</h1>
+<p>Scan to read your todos on another device</p>
+<div class="url">`)
+	buf.WriteString(todosURL)
+	buf.WriteString(`</div>`)
+	if qrErr != "" {
+		buf.WriteString(`<p class="err">QR generation failed: ` + qrErr + `</p>`)
+	} else {
+		// Embed PNG as base64 data URI.
+		buf.WriteString(`<br><img src="data:image/png;base64,`)
+		buf.WriteString(base64.StdEncoding.EncodeToString(qrPNG))
+		buf.WriteString(`" alt="QR code" width="256" height="256">`)
+	}
+	buf.WriteString(`
+</body>
+</html>`)
+	_, _ = w.Write(buf.Bytes())
+}
+
+// lanIP returns the first non-loopback IPv4 address of the host.
+// Falls back to "localhost" if none is found.
+func lanIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "localhost"
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			if ip4 := ip.To4(); ip4 != nil {
+				return ip4.String()
+			}
+		}
+	}
+	return "localhost"
+}
+

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/karimStekelenburg/dooing-tmux/internal/model"
+)
+
+
+func TestServerStartAndTodosEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use a fixed test port. Pick something unlikely to conflict.
+	port := 17291
+	srv := New(port)
+
+	todos := []*model.Todo{
+		model.NewTodo("test task #work"),
+	}
+	srv.SetTodos(todos)
+
+	errc, err := srv.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = errc
+
+	// Give the listener a moment to be ready.
+	time.Sleep(50 * time.Millisecond)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/todos", port)
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /todos: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /todos status: got %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var loaded []*model.Todo
+	if err := json.Unmarshal(body, &loaded); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Errorf("got %d todos, want 1", len(loaded))
+	}
+	if loaded[0].Text != todos[0].Text {
+		t.Errorf("todo text: got %q, want %q", loaded[0].Text, todos[0].Text)
+	}
+}
+
+func TestServerRootEndpoint(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	port := 17292
+	srv := New(port)
+	srv.SetTodos([]*model.Todo{model.NewTodo("test")})
+
+	_, err := srv.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET / status: got %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: got %q, want text/html", ct)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bs := string(body)
+	if !strings.Contains(bs, "dooing") {
+		t.Error("root page should contain 'dooing'")
+	}
+	if !strings.Contains(bs, "/todos") {
+		t.Error("root page should contain a link to /todos")
+	}
+}
+
+func TestServerShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	port := 17293
+	srv := New(port)
+	srv.SetTodos([]*model.Todo{})
+
+	errc, err := srv.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context to trigger shutdown.
+	cancel()
+
+	select {
+	case <-errc:
+		// Server stopped — good.
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not shut down within 2s")
+	}
+
+	// Further requests should fail.
+	url := fmt.Sprintf("http://127.0.0.1:%d/todos", port)
+	_, err = http.Get(url) //nolint:noctx
+	if err == nil {
+		t.Error("expected error after server shutdown, got nil")
+	}
+}
+
+func TestServerPortConflict(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	port := 17294
+	srv1 := New(port)
+	_, err := srv1.Start(ctx)
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	srv2 := New(port)
+	_, err = srv2.Start(ctx)
+	if err == nil {
+		t.Error("expected error for port conflict, got nil")
+	}
+}
+
+func TestLanIP(t *testing.T) {
+	ip := lanIP()
+	if ip == "" {
+		t.Error("lanIP returned empty string")
+	}
+	// Should be either a valid IP or "localhost".
+	if ip != "localhost" {
+		parts := strings.Split(ip, ".")
+		if len(parts) != 4 {
+			t.Errorf("lanIP = %q: not a valid IPv4 or localhost", ip)
+		}
+	}
+}
+
+func TestSetTodos(t *testing.T) {
+	srv := New(17295)
+	todos := []*model.Todo{model.NewTodo("a"), model.NewTodo("b")}
+	srv.SetTodos(todos)
+
+	srv.mu.RLock()
+	got := len(srv.todos)
+	srv.mu.RUnlock()
+
+	if got != 2 {
+		t.Errorf("SetTodos: got %d todos, want 2", got)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/karimStekelenburg/dooing-tmux/internal/config"
 	"github.com/karimStekelenburg/dooing-tmux/internal/model"
+	"github.com/karimStekelenburg/dooing-tmux/internal/server"
 	"github.com/karimStekelenburg/dooing-tmux/internal/sorter"
 	"github.com/karimStekelenburg/dooing-tmux/internal/store"
 )
@@ -168,6 +170,10 @@ type Model struct {
 
 	// Due notifications overlay.
 	notif notifState
+
+	// HTTP share server state.
+	srv       *server.Server    // nil until started
+	srvCancel context.CancelFunc // cancels the server context
 }
 
 // NewModel creates a new root model, loading todos from disk.
@@ -254,6 +260,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.notif.open {
 		return m.updateNotifications(msg)
 	}
+
+	// Handle server error message.
+	if srvErr, ok := msg.(serverErrMsg); ok {
+		if srvErr.err != nil {
+			m.statusMsg = "Share server stopped: " + srvErr.err.Error()
+			m.srv = nil
+			m.srvCancel = nil
+		}
+		return m, nil
+	}
+
 
 	// Help window intercepts input when open.
 	if m.showHelp {
@@ -392,6 +409,7 @@ func (m Model) updateInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.editingID = ""
 		m.ti.SetValue("")
 		m.ti.Blur()
+		m.syncServerTodos()
 		return m, nil
 
 	case "esc":
@@ -423,6 +441,7 @@ func (m Model) updateNormal(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch key.String() {
 	case "q", "ctrl+c":
+		m.stopServer()
 		return m, tea.Quit
 
 	// Navigation
@@ -538,6 +557,10 @@ func (m Model) updateNormal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = "Reload failed: " + err.Error()
 		}
 
+	// Share via HTTP server (QR code)
+	case "W":
+		return m.toggleServer()
+
 	// Search
 	case "/":
 		m.openSearch()
@@ -634,6 +657,7 @@ func (m Model) updateNormal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusMsg = "Todo restored"
 	}
 
+	m.syncServerTodos()
 	return m, nil
 }
 
@@ -655,6 +679,7 @@ func (m Model) deleteTodoAt(idx int) Model {
 		m.cursor = 0
 	}
 	_ = m.st.Save(m.storePath, m.todos)
+	m.syncServerTodos()
 	return m
 }
 
@@ -905,6 +930,7 @@ func renderHelpWindow() string {
 				{"f", "Reload todos from disk"},
 				{"I", "Import todos from JSON file (merge + dedup)"},
 				{"E", "Export todos to JSON file"},
+				{"W", "Toggle LAN sharing server (QR code)"},
 				{"?", "Toggle this help window"},
 				{"q / ctrl+c", "Quit"},
 			},

--- a/internal/ui/serve.go
+++ b/internal/ui/serve.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"context"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/karimStekelenburg/dooing-tmux/internal/server"
+)
+
+// serverErrMsg carries an error from the background HTTP server goroutine.
+type serverErrMsg struct{ err error }
+
+// toggleServer starts the HTTP share server if it is not running, or stops it
+// if it is. Returns the updated model and any command to run.
+func (m Model) toggleServer() (tea.Model, tea.Cmd) {
+	if m.srv != nil {
+		// Server already running — stop it.
+		m.stopServer()
+		m.statusMsg = "Share server stopped"
+		return m, nil
+	}
+
+	port := m.cfg.ServePort
+	if port <= 0 {
+		port = 7283
+	}
+
+	srv := server.New(port)
+	srv.SetTodos(m.todos)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc, err := srv.Start(ctx)
+	if err != nil {
+		cancel()
+		m.statusMsg = "Share server error: " + err.Error()
+		return m, nil
+	}
+
+	m.srv = srv
+	m.srvCancel = cancel
+	m.statusMsg = "Sharing at http://" + srv.Addr() + "  (QR: http://" + srv.Addr() + "/)"
+
+	// Forward any server error back as a tea.Msg so the user sees it.
+	return m, func() tea.Msg {
+		err := <-errc
+		if err != nil {
+			return serverErrMsg{err: err}
+		}
+		return serverErrMsg{}
+	}
+}
+
+// stopServer shuts down the HTTP server if running.
+func (m *Model) stopServer() {
+	if m.srvCancel != nil {
+		m.srvCancel()
+		m.srvCancel = nil
+	}
+	m.srv = nil
+}
+
+// syncServerTodos pushes the current todos to the running server (if any).
+func (m Model) syncServerTodos() {
+	if m.srv != nil {
+		m.srv.SetTodos(m.todos)
+	}
+}
+
+// StartServer starts the HTTP share server and returns the updated model.
+// This is intended for use from main.go when the --serve flag is provided.
+func (m Model) StartServer() Model {
+	newM, _ := m.toggleServer()
+	return newM.(Model)
+}

--- a/main.go
+++ b/main.go
@@ -11,9 +11,13 @@ import (
 
 func main() {
 	project := flag.Bool("project", false, "use project-scoped todos (git root)")
+	serve := flag.Bool("serve", false, "start the LAN sharing HTTP server immediately")
 	flag.Parse()
 
 	m := ui.NewModel(*project)
+	if *serve {
+		m = m.StartServer()
+	}
 
 	// When running inside a tmux popup (TMUX env var set), skip the alternate
 	// screen so tmux provides the surrounding frame.


### PR DESCRIPTION
## Summary

- New `internal/server` package: read-only HTTP server on port 7283 (configurable via `serve_port` in config)
- `GET /todos` returns current todos as pretty-printed JSON
- `GET /` returns a styled HTML page with an embedded PNG QR code pointing to the LAN `/todos` URL
- Auto-detects LAN IP (first non-loopback IPv4 interface, falls back to `localhost`)
- Server runs in a background goroutine; context cancellation drives clean shutdown
- `W` keybind toggles the server from within the TUI; status bar shows the full URL when active
- `--serve` CLI flag starts the server immediately on launch
- Adds `serve_port` (default `7283`) to Config

Closes #16

## Test plan

- [x] `GET /todos` returns valid JSON with correct todos after `SetTodos`
- [x] `GET /` returns `text/html` with "dooing" and a `/todos` reference
- [x] Context cancellation shuts server down cleanly (error channel closes)
- [x] Starting a second server on the same port returns a clear error
- [x] `lanIP()` returns a valid IPv4 address or "localhost"
- [x] `SetTodos` is concurrency-safe (RWMutex)
- [x] Full `go test ./...` passes